### PR TITLE
fix: enable electron nodeIntegration

### DIFF
--- a/src/app/main/core.cljs
+++ b/src/app/main/core.cljs
@@ -6,7 +6,9 @@
 (defn init-browser []
   (reset! main-window (BrowserWindow.
                         (clj->js {:width 800
-                                  :height 600})))
+                                  :height 600
+                                  :webPreferences
+                                  {:nodeIntegration true}})))
   ; Path is relative to the compiled js file (main.js in our case)
   (.loadURL @main-window (str "file://" js/__dirname "/public/index.html"))
   (.on @main-window "closed" #(reset! main-window nil)))


### PR DESCRIPTION
Electron no longer enables node modules by default. This opts in when
starting up the electron process.

The symptom was a forlorn `require is not defined`.

Reference: https://stackoverflow.com/questions/44391448/electron-require-is-not-defined